### PR TITLE
Update 10-supp-addressing-data.Rmd

### DIFF
--- a/_episodes_rmd/10-supp-addressing-data.Rmd
+++ b/_episodes_rmd/10-supp-addressing-data.Rmd
@@ -226,7 +226,7 @@ x < 10
 x %in% 1:10
 ```
 
-We can use logical vectors to select data from a data frame.
+We can use logical vectors to select data from a data frame. This is often referred to as *logical indexing*. 
 
 ```{r logical_vectors_addressing}
 index <- dat$Group == 'Control'

--- a/_episodes_rmd/10-supp-addressing-data.Rmd
+++ b/_episodes_rmd/10-supp-addressing-data.Rmd
@@ -204,7 +204,7 @@ dat2 <- read.csv(file = 'data/sample.csv', header = TRUE, stringsAsFactors = FAL
 
 
 
-### Logical Indexing
+### Addressing by Logical Vector
 
 A logical vector contains only the special values `TRUE` and `FALSE`.
 
@@ -228,14 +228,14 @@ x %in% 1:10
 
 We can use logical vectors to select data from a data frame.
 
-```{r logical_vectors_indexing}
+```{r logical_vectors_addressing}
 index <- dat$Group == 'Control'
 dat[index,]$BloodPressure
 ```
 
 Often this operation is written as one line of code:
 
-```{r logical_vectors_indexing2}
+```{r logical_vectors_addressing2}
 plot(dat[dat$Group == 'Control', ]$BloodPressure)
 ```
 
@@ -256,11 +256,11 @@ plot(dat[dat$Group == 'Control', ]$BloodPressure)
 {: .challenge}
 
 
-### Combining Indexing and Assignment
+### Combining Addressing and Assignment
 
-The assignment operator `<-` can be combined with indexing.
+The assignment operator `<-` can be combined with addressing.
 
-```{r indexing and assignment}
+```{r addressing and assignment}
 x <- c(1, 2, 3, 11, 12, 13)
 x[x < 10] <- 0
 x
@@ -269,7 +269,7 @@ x
 > ## Updating a Subset of Values
 >
 > In this dataset, values for Gender have been recorded as both uppercase `M, F` and lowercase `m, f`.
-> Combine the indexing and assignment operations to convert all values to lowercase.
+> Combine the addressing and assignment operations to convert all values to lowercase.
 > 
 > > ## Solution
 > > ~~~


### PR DESCRIPTION
Dear Carpentries Community,

In my instructor training I learnt about "fluid representations" where multiple words for the same concept can confuse learners. I noticed that in the Addressing Data most of the lesson is really careful to avoid fluid representations, by consistently using the word addressing to describe accessing parts of a data frame, rather than mixing in words like subsetting or indexing. However, the titles for the three sections of the types of addressing are:
Addressing by Index
Addressing by Name
Logical Indexing

To fix this issue I suggest replace 'indexing' with 'addressing' across the whole document (as that terminology is only used right at the end) and changing the title 'Logical Indexing' to 'Addressing by Logical Vector'.

Cheers,

Elena

